### PR TITLE
feat: stream agent responses

### DIFF
--- a/songbird/agent/agent_core.py
+++ b/songbird/agent/agent_core.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from rich.text import Text
 
 from ..llm.providers import BaseProvider
+from ..llm.unified_interface import create_provider_adapter
+from ..llm.types import ChatResponse
 from ..ui.data_transfer import UIMessage, AgentOutput
 from ..memory.models import Session, Message
 from ..memory.optimized_manager import OptimizedSessionManager
@@ -51,6 +53,7 @@ class AgentCore:
         self.plan_manager = PlanManager()
         self.message_classifier = MessageClassifier(self.provider)
         self.file_context_manager = FileContextManager()
+        self.provider_adapter = create_provider_adapter(provider)
         
         # Load system prompt from centralized prompts
         from ..prompts import get_core_system_prompt
@@ -231,14 +234,61 @@ class AgentCore:
                 logger.debug(f"Iteration {iteration_count}: Starting with {consecutive_no_tools} consecutive no-tool turns")
             
             tools = self.tool_runner.get_available_tools()
-            
+
             messages = self._build_messages_for_llm()
-            
+
             if verbose_logging:
-                logger.debug(f"Iteration {iteration_count}: Requesting LLM response with {len(tools)} tools available")
-            
-            response = await self.provider.chat_with_messages(messages, tools=tools)
-            
+                logger.debug(
+                    f"Iteration {iteration_count}: Requesting LLM response with {len(tools)} tools available"
+                )
+
+            ui_layer = getattr(self.tool_runner, "ui_layer", None)
+            capabilities = self.provider_adapter.get_provider_capabilities()
+            supports_streaming = (
+                capabilities.get("supports_streaming", False)
+                and hasattr(self.provider, "stream_chat")
+            )
+
+            streaming_mode = False
+            if supports_streaming:
+                try:
+                    streaming_mode = True
+                    if ui_layer and ui_layer.is_thinking():
+                        await ui_layer.hide_thinking()
+                    if ui_layer:
+                        await ui_layer.start_stream()
+
+                    full_content = ""
+                    tool_calls: List[Dict[str, Any]] = []
+                    async for chunk in self.provider.stream_chat(messages, tools=tools):
+                        token = chunk.get("content")
+                        if token:
+                            full_content += token
+                            if ui_layer:
+                                await ui_layer.stream_token(token)
+                        if chunk.get("tool_calls"):
+                            tool_calls.extend(chunk["tool_calls"])
+
+                    if ui_layer:
+                        await ui_layer.end_stream()
+
+                    response = ChatResponse(
+                        content=full_content,
+                        tool_calls=tool_calls or None,
+                    )
+                except Exception as e:
+                    streaming_mode = False
+                    logger.warning(
+                        f"Streaming failed, falling back to non-streaming: {e}"
+                    )
+                    if ui_layer:
+                        await ui_layer.end_stream()
+                    response = await self.provider.chat_with_messages(
+                        messages, tools=tools
+                    )
+            else:
+                response = await self.provider.chat_with_messages(messages, tools=tools)
+
             if response.content:
                 total_tokens_used += len(response.content.split()) * 1.3  # Rough approximation
             
@@ -297,17 +347,26 @@ class AgentCore:
                     logger.info(f"Iteration {iteration_count}: Two consecutive no-tool turns - terminating (task likely complete)")
                     # Two consecutive turns without tools - task likely complete
                     await self._add_final_assistant_message(response)
-                    assistant_message = UIMessage.assistant(response.content or "")
+                    assistant_message = UIMessage.assistant(
+                        response.content or "",
+                        streamed=streaming_mode,
+                    )
                     return AgentOutput.completion(assistant_message)
                 elif await self._should_terminate_loop(iteration_count, consecutive_no_tools, total_tokens_used, max_tokens_budget):
                     # Other termination criteria met
                     await self._add_final_assistant_message(response)
-                    assistant_message = UIMessage.assistant(response.content or "")
+                    assistant_message = UIMessage.assistant(
+                        response.content or "",
+                        streamed=streaming_mode,
+                    )
                     return AgentOutput.completion(assistant_message)
                 else:
                     # Add message and continue (might need clarification)
                     await self._add_final_assistant_message(response)
-                    assistant_message = UIMessage.assistant(response.content or "")
+                    assistant_message = UIMessage.assistant(
+                        response.content or "",
+                        streamed=streaming_mode,
+                    )
                     return AgentOutput.completion(assistant_message)
         
         # Maximum iterations reached

--- a/songbird/llm/unified_interface.py
+++ b/songbird/llm/unified_interface.py
@@ -113,6 +113,20 @@ class ProviderAdapter:
             "max_context_length": self._get_max_context_length(),
             "tool_call_format": self._get_tool_call_format()
         }
+
+        # Try loading capability information from provider mapping
+        try:
+            from ..config.mapping_loader import load_provider_mapping
+
+            mapping = load_provider_mapping()
+            provider_cfg = mapping.get_provider_config(self.provider_name)
+            if provider_cfg and "supports_streaming" in provider_cfg:
+                base_capabilities["supports_streaming"] = bool(
+                    provider_cfg["supports_streaming"]
+                )
+        except Exception:
+            # If mapping can't be loaded, keep default value
+            pass
         
         # Provider-specific capabilities
         if self.provider_name == "ollama":

--- a/songbird/ui/ui_layer.py
+++ b/songbird/ui/ui_layer.py
@@ -48,10 +48,12 @@ class UILayer:
         
     async def display_message(self, message: UIMessage) -> None:
         """Display a message with appropriate styling."""
+        if message.metadata and message.metadata.get("streamed"):
+            return
+
         # In quiet mode, only show final assistant responses
         if self.quiet_mode:
             if message.message_type == MessageType.ASSISTANT:
-                # Show only the content without any formatting in quiet mode
                 print(message.content)
             elif message.message_type == MessageType.ERROR:
                 self._display_error_message(message)
@@ -253,6 +255,29 @@ class UILayer:
         if self._thinking_status:
             self._thinking_status.stop()
             self._thinking_status = None
+
+    async def start_stream(self) -> None:
+        """Prepare UI for streaming assistant tokens."""
+        if self.quiet_mode:
+            print()
+            return
+        self.console.print("\n[medium_spring_green]Songbird:[/medium_spring_green] ", end="")
+        self.console.file.flush()
+
+    async def stream_token(self, token: str) -> None:
+        """Stream a token of assistant text."""
+        if self.quiet_mode:
+            print(token, end="", flush=True)
+            return
+        self.console.print(token, end="")
+        self.console.file.flush()
+
+    async def end_stream(self) -> None:
+        """Finalize streaming output."""
+        if self.quiet_mode:
+            print()
+            return
+        self.console.print("")
     
     async def pause_thinking(self) -> None:
         """Temporarily pause thinking indicator for tool output."""


### PR DESCRIPTION
## Summary
- stream agentic loop responses when provider supports it
- add UI helpers for token streaming
- expose provider streaming capability through adapter

## Testing
- `pytest` *(fails: tests/test_copilot.py::test_copilot_chat_basic - Exception: GitHub Copilot API request failed: 403 Forbidden, tests/test_copilot.py::test_copilot_chat_with_usage - Exception: GitHub Copilot API request failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f75e1f4b88327bd7116a48dfc901f